### PR TITLE
fix: improve best guess for the correct locale when generating links …

### DIFF
--- a/src/module/KankaBrowser.ts
+++ b/src/module/KankaBrowser.ts
@@ -1,3 +1,4 @@
+import api from '../kanka/api';
 import Campaign from '../kanka/entities/Campaign';
 import PrimaryEntity from '../kanka/entities/PrimaryEntity';
 import { logError } from '../logger';
@@ -99,6 +100,7 @@ export default class KankaBrowser extends Application {
     async getData(): Promise<TemplateData> {
         // Clear cache on every reload to ensure that the lists always shows all current elements
         const campaign = await this.getCampaign();
+        const profile = await api.getProfile();
 
         Handlebars.registerHelper('kankaLink', (type?: string, id?: number) => {
             let saneType;
@@ -112,7 +114,7 @@ export default class KankaBrowser extends Application {
                 saneId = id;
             }
 
-            return createKankaLink(campaign.id, saneType, saneId, campaign.locale);
+            return createKankaLink(campaign.id, saneType, saneId, profile.locale || campaign.locale);
         });
 
         Handlebars.registerHelper('hasKankaJournalEntry', (entity: PrimaryEntity) => {

--- a/src/util/createKankaLink.ts
+++ b/src/util/createKankaLink.ts
@@ -1,5 +1,5 @@
-export default function createKankaLink(campaignId: number, type?: string, id?: number, locale = 'en'): string {
-    const parts = [`https://kanka.io/${locale}/campaign/${campaignId}`];
+export default function createKankaLink(campaignId: number, type?: string, id?: number, locale?: string): string {
+    const parts = [`https://kanka.io/${locale || 'en'}/campaign/${campaignId}`];
 
     if (type) {
         const pluralType = `${type.replace(/y$/, 'ie')}s`;


### PR DESCRIPTION
…to kanka

The previous solution took the campaign language or fell back to english.
But it didn't catch cases where the campaign locale was an empty string instead
of null or undefined.

In addition I now take the users profile into account and use that locale if possible.

fixes #27