### PR TITLE
fix: activate JournalEntry for latest documentSheetRegistrar

### DIFF
--- a/src/hooks/preDocumentSheetRegistrarInit.ts
+++ b/src/hooks/preDocumentSheetRegistrarInit.ts
@@ -1,0 +1,14 @@
+export default function preDocumentSheetRegistrarInit(settings: {
+    Actor: boolean;
+    Folder: boolean;
+    Item: boolean;
+    JournalEntry: boolean;
+    Macro: boolean;
+    Playlist: boolean;
+    RollTable: boolean;
+    Scene: boolean;
+    User: boolean;
+}): void {
+    // eslint-disable-next-line no-param-reassign
+    settings.JournalEntry = true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import deleteJournalEntry from './hooks/deleteJournalEntry';
 import hmrWrapHook from './hooks/hmrWrapHook';
 import init from './hooks/init';
+import preDocumentSheetRegistrarInit from './hooks/preDocumentSheetRegistrarInit';
 import ready from './hooks/ready';
 import renderJournalDirectory from './hooks/renderJournalDirectory';
 import renderSettingsConfig from './hooks/renderSettingsConfig';
 import './index.scss';
 import './KankaJournal/KankaJournalApplication';
 
+const refreshPreDocumentSheetRegistrarInit = hmrWrapHook('preDocumentSheetRegistrarInit', () => preDocumentSheetRegistrarInit, 'once');
 const refreshInit = hmrWrapHook('init', () => init, 'once');
 const refreshReady = hmrWrapHook('ready', () => ready, 'once');
 const refreshRenderJournalDirectory = hmrWrapHook('renderJournalDirectory', () => renderJournalDirectory, 'on');
@@ -14,6 +16,7 @@ const refreshRenderSettingsConfig = hmrWrapHook('renderSettingsConfig', () => re
 const refreshDeleteJournalSheet = hmrWrapHook('deleteJournalEntry', () => deleteJournalEntry, 'on');
 
 if (module.hot) {
+    module.hot.accept('./hooks/preDocumentSheetRegistrarInit', refreshPreDocumentSheetRegistrarInit);
     module.hot.accept('./hooks/init', refreshInit);
     module.hot.accept('./hooks/ready', refreshReady);
     module.hot.accept('./hooks/renderJournalDirectory', refreshRenderJournalDirectory);


### PR DESCRIPTION
A new hook is required to be called which activates the DocumentSheetRegistrar wires for JournalEntries