### PR TITLE
Updates for v9

### DIFF
--- a/src/util/createJournalLink.ts
+++ b/src/util/createJournalLink.ts
@@ -1,7 +1,7 @@
 export default function createJournalLink(
     entry: JournalEntry,
     label?: string,
-    classes = 'entity-link',
+    classes = 'entity-link content-link',
 ): string {
-    return `<a draggable="true" data-entity="JournalEntry" data-id="${entry.id}" class="${classes}"><i class="fas fa-book-open"></i> ${label ?? entry.name}</a>`;
+    return `<a draggable="true" data-entity="JournalEntry" data-tyep="JournalEntry" data-id="${entry.id}" class="${classes}"><i class="fas fa-book-open"></i> ${label ?? entry.name}</a>`;
 }

--- a/src/util/createJournalLink.ts
+++ b/src/util/createJournalLink.ts
@@ -3,5 +3,5 @@ export default function createJournalLink(
     label?: string,
     classes = 'entity-link content-link',
 ): string {
-    return `<a draggable="true" data-entity="JournalEntry" data-tyep="JournalEntry" data-id="${entry.id}" class="${classes}"><i class="fas fa-book-open"></i> ${label ?? entry.name}</a>`;
+    return `<a draggable="true" data-entity="JournalEntry" data-type="JournalEntry" data-id="${entry.id}" class="${classes}"><i class="fas fa-book-open"></i> ${label ?? entry.name}</a>`;
 }


### PR DESCRIPTION
I did a little poking around and it appears that `data-type="JournalEntry"` and `class="entity-link content-link"` are required. Once I added those manually to one of the elements it was clickable. (I poked at the regular journal entries to see what the difference was). 

`classes = 'entity-link content-link',` also works, but `entity-link` is used in a number of styles, so I left it in for now.

I'm unsure how to test the changes in this PR to ensure I got it everywhere, but from my quick look in the code base, this seems like the right place.

Fixes #85 (I think)