### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@ plugins:
     - '@semantic-release/npm'
     - '@semantic-release/changelog'
     - '@semantic-release/git'
-    - - '@google/semantic-release-replace-plugin'
+    - - 'semantic-release-replace-plugin'
       - replacements:
             - files: [dist/module.json]
               from: '__VERSION__'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,12 @@
     "packages": {
         "": {
             "name": "kanka-foundry",
-            "version": "3.1.6",
+            "version": "3.1.7",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^3.1.2"
             },
             "devDependencies": {
-                "@google/semantic-release-replace-plugin": "^1.1.0",
                 "@league-of-foundry-developers/foundry-vtt-types": "^9.280.0",
                 "@semantic-release/changelog": "^6.0.0",
                 "@semantic-release/exec": "^6.0.1",
@@ -32,6 +31,7 @@
                 "mockdate": "^3.0.5",
                 "sass": "^1.52.1",
                 "semantic-release": "^21.0.0",
+                "semantic-release-replace-plugin": "^1.1.0",
                 "ts-node": "^10.3.0",
                 "typescript": "^5.0.2",
                 "vite": "^4.2.1",
@@ -580,17 +580,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/@google/semantic-release-replace-plugin": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@google/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.0.tgz",
-            "integrity": "sha512-ucZHG4eOtWjW+mSD3GSHg/LKyqY4N5KYk/QYpWD580FDE7eii0fmns9v0jpbsDj8W+pV7QXmbSDqIpPVfBrptg==",
-            "dev": true,
-            "dependencies": {
-                "jest-diff": "^26.5.2",
-                "lodash": "^4.17.20",
-                "replace-in-file": "^6.1.0"
-            }
-        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.8",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -633,20 +622,16 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jest/types": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+        "node_modules/@jest/schemas": {
+            "version": "29.6.0",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+            "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
             "dev": true,
             "dependencies": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^4.0.0"
+                "@sinclair/typebox": "^0.27.8"
             },
             "engines": {
-                "node": ">= 10.14.2"
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -3400,6 +3385,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.27.8",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "dev": true
+        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
@@ -3457,24 +3448,6 @@
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
             "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
             "dev": true
-        },
-        "node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-            "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-            "dev": true,
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "*"
-            }
-        },
-        "node_modules/@types/istanbul-reports": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-            "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-            "dev": true,
-            "dependencies": {
-                "@types/istanbul-lib-report": "*"
-            }
         },
         "node_modules/@types/jquery": {
             "version": "3.5.16",
@@ -3541,21 +3514,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-            "dev": true
-        },
-        "node_modules/@types/yargs": {
-            "version": "15.0.15",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
-            "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@types/yargs-parser": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-            "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4792,15 +4750,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.14.2"
             }
         },
         "node_modules/dir-glob": {
@@ -6767,30 +6716,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
-            }
-        },
-        "node_modules/jest-diff": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^26.6.2",
-                "jest-get-type": "^26.3.0",
-                "pretty-format": "^26.6.2"
-            },
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
-        "node_modules/jest-get-type": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.14.2"
             }
         },
         "node_modules/js-string-escape": {
@@ -11549,21 +11474,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/pretty-format": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-            "dev": true,
-            "dependencies": {
-                "@jest/types": "^26.6.2",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11953,64 +11863,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/replace-in-file": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.3.5.tgz",
-            "integrity": "sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.1.2",
-                "glob": "^7.2.0",
-                "yargs": "^17.2.1"
-            },
-            "bin": {
-                "replace-in-file": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/replace-in-file/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/replace-in-file/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/replace-in-file/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12197,6 +12049,180 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.6.tgz",
+            "integrity": "sha512-/0aRwQ3taocrfIOYQ94IQHVUYJXyVGkhJCBNp2dagE4KKghGPMWKGaisvxveJV28X4V9PogxCvHdTd+Rrz8kxw==",
+            "dev": true,
+            "dependencies": {
+                "jest-diff": "^29.6.0",
+                "lodash-es": "^4.17.21",
+                "replace-in-file": "^7.0.1"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/diff-sequences": {
+            "version": "29.4.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+            "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/jest-diff": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
+            "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^29.4.3",
+                "jest-get-type": "^29.4.3",
+                "pretty-format": "^29.6.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/jest-get-type": {
+            "version": "29.4.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+            "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/pretty-format": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+            "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+            "dev": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.0",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+            "dev": true
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/replace-in-file": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-7.0.1.tgz",
+            "integrity": "sha512-KbhgPq04eA+TxXuUxpgWIH9k/TjF+28ofon2PXP7vq6izAILhxOtksCVcLuuQLtyjouBaPdlH6RJYYcSPVxCOA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "glob": "^8.1.0",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "replace-in-file": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/semantic-release-replace-plugin/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/semantic-release/node_modules/aggregate-error": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "author": "Steven Weingärtner",
     "license": "MIT",
     "devDependencies": {
-        "@google/semantic-release-replace-plugin": "^1.1.0",
+        "semantic-release-replace-plugin": "^1.1.0",
         "@league-of-foundry-developers/foundry-vtt-types": "^9.280.0",
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/exec": "^6.0.1",


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).