### PR TITLE
Prepare code for Kanka 2.0

### DIFF
--- a/src/api/KankaApi.ts
+++ b/src/api/KankaApi.ts
@@ -23,7 +23,7 @@ import RateLimiter from './RateLimiter';
 export default class KankaApi {
     #fetcher: KankaFetcher;
 
-    public constructor(baseUrl = 'https://kanka.io/api/1.0') {
+    public constructor(baseUrl = 'https://api.kanka.io/1.0') {
         this.#fetcher = new KankaFetcher(baseUrl);
     }
 
@@ -170,7 +170,7 @@ export default class KankaApi {
     public async getAllLocations(campaignId: KankaApiId): Promise<KankaApiLocation[]> {
         return this.fetchFullListWithAncestors(
             `campaigns/${Number(campaignId)}/locations?related=1`,
-            'parent_location_id',
+            'location_id',
         );
     }
 

--- a/src/api/KankaFetcher.ts
+++ b/src/api/KankaFetcher.ts
@@ -78,8 +78,9 @@ export default class KankaFetcher {
             result = `${result}/`;
         }
 
-        if (!result.endsWith('api/1.0/')) {
-            result = `${result}api/1.0/`;
+        // Self-hosted people on the old schema will still have api/1.0, but Kanka's api is now on its own subdomain
+        if (!result.endsWith('1.0/')) {
+            result = `${result}1.0/`;
         }
 
         if (!result.startsWith('http')) {

--- a/src/api/typeLoaders/LocationTypeLoader.test.ts
+++ b/src/api/typeLoaders/LocationTypeLoader.test.ts
@@ -198,7 +198,7 @@ describe('LocationTypeLoader', () => {
 
         it('includes parent from the lookup array', async () => {
             const expectedResult = createLocation({
-                parent_location_id: 2002,
+                location_id: 2002,
             });
 
             const entities = [

--- a/src/api/typeLoaders/LocationTypeLoader.ts
+++ b/src/api/typeLoaders/LocationTypeLoader.ts
@@ -16,7 +16,7 @@ export default class LocationTypeLoader extends AbstractTypeLoader<KankaApiLocat
         const collection = await super.createReferenceCollection(campaignId, entity, lookup);
 
         await Promise.all([
-            collection.addById(entity.parent_location_id, 'location'),
+            collection.addById(entity.location_id, 'location'),
             ...entity.ancestors.map(ancestor => collection.addByEntityId(ancestor)),
             ...entity.children.map(child => collection.addByEntityId(child.entity_id)),
         ]);

--- a/src/types/kanka.ts
+++ b/src/types/kanka.ts
@@ -328,7 +328,7 @@ export interface KankaApiJournal extends KankaApiChildEntity {
 export interface KankaApiLocation extends KankaApiChildEntity {
     ancestors: KankaApiEntityId[];
     children: KankaApiChild[];
-    parent_location_id: KankaApiId | null;
+    location_id: KankaApiId | null;
     type: string | null;
 }
 


### PR DESCRIPTION
Made some changes to the code to support Kanka 2.0 coming out on Wednesday 25th of October.

* `location.parent_location_id` becomes `location.location_id`
* The API domain becomes api.kanka.io/1.0

Feel free to ignore as I only did a search and replace. I don't have a way of testing this, but maybe it helps speed it up on your end :)