### PR TITLE
Removed  redundant mapping of data folder volume. Mapping over image …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
             - source: config_json
               target: config.json
         volumes:
-            - ./data:/data
             - ./dist:/data/Data/modules/kanka-foundry
         init: true
         restart: unless-stopped


### PR DESCRIPTION
…/data path will change permissions back to root user and break permissions required to run foundry. See https://github.com/felddy/foundryvtt-docker/pull/1241

This change complements https://github.com/felddy/foundryvtt-docker/pull/1241/commits/d0dc1bb37fb31990e340cad313a84baab33197fa
